### PR TITLE
Update syntactic class names for Atom 1.13

### DIFF
--- a/styles/angular.less
+++ b/styles/angular.less
@@ -1,9 +1,9 @@
-.angular {
-  .entity.other.attribute-name {
+.syntax--angular {
+  .syntax--entity.syntax--other.syntax--attribute-name {
     color: @orange !important;
   }
 
-  .punctuation.definition.block {
+  .syntax--punctuation.syntax--definition.syntax--block {
     color: @yellow !important;
     background-color: fadeout(@yellow, 93%);
   }

--- a/styles/base.less
+++ b/styles/base.less
@@ -1,230 +1,230 @@
-.comment {
+.syntax--comment {
   color: @comment;
 }
 
-.entity {
-  &.name.type {
+.syntax--entity {
+  &.syntax--name.syntax--type {
     color: @yellow;
   }
 
-  &.name.function {
+  &.syntax--name.syntax--function {
     color: @blue;
   }
 
-  &.name.class, &.name.type.class {
+  &.syntax--name.syntax--class, &.syntax--name.syntax--type.syntax--class {
     color: @yellow;
   }
 
-  &.name.section {
+  &.syntax--name.syntax--section {
     color: @blue;
   }
 
-  &.name.tag {
+  &.syntax--name.syntax--tag {
     color: @red;
   }
 
-  &.other.attribute-name {
+  &.syntax--other.syntax--attribute-name {
     color: @orange;
 
-    &.id {
+    &.syntax--id {
       color: @blue;
     }
   }
 
-  &.other.inherited-class {
+  &.syntax--other.syntax--inherited-class {
     color: @red;
   }
 }
 
-.keyword {
+.syntax--keyword {
   color: @purple;
 
-  &.control {
+  &.syntax--control {
     color: @purple;
   }
 
-  &.operator {
+  &.syntax--operator {
     color: @syntax-text-color;
   }
 
-  &.other.special-method {
+  &.syntax--other.syntax--special-method {
     color: @blue;
   }
 
-  &.other.unit {
+  &.syntax--other.syntax--unit {
     color: @orange;
   }
 }
 
-.storage {
+.syntax--storage {
   color: @purple;
 }
 
-.constant {
+.syntax--constant {
   color: @orange;
 
-  &.character.escape {
+  &.syntax--character.syntax--escape {
     color: @aqua;
   }
 
-  &.numeric {
+  &.syntax--numeric {
     color: @orange;
   }
 
-  &.other.color {
+  &.syntax--other.syntax--color {
     color: @aqua;
   }
 
-  &.other.symbol {
+  &.syntax--other.syntax--symbol {
     color: @green;
   }
 }
 
-.variable {
+.syntax--variable {
   color: @red;
 
-  &.interpolation {
+  &.syntax--interpolation {
     color: darken(@red, 10%);
   }
 
-  &.parameter.function {
+  &.syntax--parameter.syntax--function {
     color: @syntax-text-color;
   }
 }
 
-.invalid.illegal {
+.syntax--invalid.syntax--illegal {
   background-color: @red;
   color: @syntax-background-color;
 }
 
-.string {
+.syntax--string {
   color: @green;
 
-  &.regexp {
+  &.syntax--regexp {
     color: @aqua;
 
-    .source.ruby.embedded {
+    .syntax--source.syntax--ruby.syntax--embedded {
       color: @orange;
     }
   }
 
-  &.other.link {
+  &.syntax--other.syntax--link {
     color: @red;
   }
 }
 
-.punctuation {
-  &.definition {
-    &.comment {
+.syntax--punctuation {
+  &.syntax--definition {
+    &.syntax--comment {
       color: @comment;
     }
 
-    &.string,
-    &.variable,
-    &.parameters,
-    &.array {
+    &.syntax--string,
+    &.syntax--variable,
+    &.syntax--parameters,
+    &.syntax--array {
       color: @syntax-text-color;
     }
 
-    &.heading,
-    &.identity {
+    &.syntax--heading,
+    &.syntax--identity {
       color: @blue;
     }
 
-    &.bold {
+    &.syntax--bold {
       color: @yellow;
       font-style: bold;
     }
 
-    &.italic {
+    &.syntax--italic {
       color: @purple;
       font-style: italic;
     }
   }
 
-  &.section.embedded {
+  &.syntax--section.syntax--embedded {
     color: @yellow;
     background-color: fadeout(@yellow, 93%);
   }
 }
 
-.support {
-  &.class {
+.syntax--support {
+  &.syntax--class {
     color: @yellow;
   }
 
-  &.function  {
+  &.syntax--function  {
     color: @blue;
 
-    &.any-method {
+    &.syntax--any-method {
       color: @blue;
     }
   }
 }
 
-.meta {
-  &.class {
+.syntax--meta {
+  &.syntax--class {
     color: @yellow;
   }
 
-  &.link {
+  &.syntax--link {
     color: @orange;
   }
 
-  &.require {
+  &.syntax--require {
     color: @blue;
   }
 
-  &.selector {
+  &.syntax--selector {
     color: @purple;
   }
 
-  &.separator {
+  &.syntax--separator {
     background-color: @current-line;
     color: @syntax-text-color;
   }
 }
 
-.none {
+.syntax--none {
   color: @syntax-text-color;
 }
 
-.markup {
-  &.bold {
+.syntax--markup {
+  &.syntax--bold {
     color: @orange;
     font-style: bold;
   }
 
-  &.changed {
+  &.syntax--changed {
     color: @purple;
   }
 
-  &.deleted {
+  &.syntax--deleted {
     color: @red;
   }
 
-  &.italic {
+  &.syntax--italic {
     color: @purple;
     font-style: italic;
   }
 
-  &.heading .punctuation.definition.heading {
+  &.syntax--heading .syntax--punctuation.syntax--definition.syntax--heading {
     color: @blue;
   }
 
-  &.inserted {
+  &.syntax--inserted {
     color: @green;
   }
 
-  &.list {
+  &.syntax--list {
     color: @red;
   }
 
-  &.quote {
+  &.syntax--quote {
     color: @orange;
   }
 
-  &.raw.inline {
+  &.syntax--raw.syntax--inline {
     color: @green;
   }
 }

--- a/styles/coffee.less
+++ b/styles/coffee.less
@@ -1,28 +1,28 @@
-.coffee {
-  &.keyword.operator {
+.syntax--coffee {
+  &.syntax--keyword.syntax--operator {
     color: @aqua;
   }
 
-  &.variable.assignment {
+  &.syntax--variable.syntax--assignment {
     color: @orange;
   }
 
-  &.meta.brace.square {
+  &.syntax--meta.syntax--brace.syntax--square {
     color: @blue;
     background-color: fadeout(@blue, 93%);
   }
 
-  &.meta.brace.curly {
+  &.syntax--meta.syntax--brace.syntax--curly {
     color: @red;
     background-color: fadeout(@red, 93%);
   }
 
-  &.meta.brace.round {
+  &.syntax--meta.syntax--brace.syntax--round {
     color: @aqua;
     background-color: fadeout(@aqua, 93%);
   }
 
-  &.punctuation.definition.string {
+  &.syntax--punctuation.syntax--definition.syntax--string {
     color: @green;
     background-color: fadeout(@green, 93%);
   }

--- a/styles/editor.less
+++ b/styles/editor.less
@@ -1,4 +1,4 @@
-atom-text-editor, :host {
+atom-text-editor {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
 

--- a/styles/gfm.less
+++ b/styles/gfm.less
@@ -1,46 +1,46 @@
-.gfm {
+.syntax--gfm {
   -webkit-font-smoothing: auto;
 
-  .marker {
+  .syntax--marker {
     color: @red;
   }
 
-  .bold {
+  .syntax--bold {
     color: @yellow;
     font-style: bold;
   }
 
-  .italic {
+  .syntax--italic {
     color: @purple;
     font-style: italic;
   }
 
-  .quote {
+  .syntax--quote {
     color: @green;
   }
 
-  .list {
+  .syntax--list {
     color: @aqua;
   }
 
-  .link {
+  .syntax--link {
     color: @blue;
 
-    & .entity {
+    & .syntax--entity {
       color: @foreground;
     }
 
-    & .begin,
-    & .end {
+    & .syntax--begin,
+    & .syntax--end {
       background-color: fadeout(@blue, 93%);
     }
   }
 
-  .raw {
+  .syntax--raw {
     color: darken(@foreground, 12%);
   }
 
-  .hr {
+  .syntax--hr {
     background-color: @current-line;
     color: @foreground;
   }

--- a/styles/haml.less
+++ b/styles/haml.less
@@ -1,5 +1,5 @@
-.haml {
-  &.punctuation.definition.tag {
+.syntax--haml {
+  &.syntax--punctuation.syntax--definition.syntax--tag {
     color: @red;
   }
 }

--- a/styles/html.less
+++ b/styles/html.less
@@ -1,9 +1,9 @@
-.html {
-  .meta.tag.sgml.doctype {
+.syntax--html {
+  .syntax--meta.syntax--tag.syntax--sgml.syntax--doctype {
     color: @purple;
   }
 
-  .punctuation.definition.string {
+  .syntax--punctuation.syntax--definition.syntax--string {
     color: @green;
     background-color: fadeout(@green, 93%);
   }

--- a/styles/js.less
+++ b/styles/js.less
@@ -1,99 +1,99 @@
-.js {
-  &.constant.other.property {
+.syntax--js {
+  &.syntax--constant.syntax--other.syntax--property {
     color: @foreground;
   }
 
-  &.keyword.operator {
+  &.syntax--keyword.syntax--operator {
     color: @aqua;
   }
 
-  &.variable {
+  &.syntax--variable {
     color: @foreground;
 
-    &.class {
+    &.syntax--class {
       color: @red;
     }
 
-    &.language {
+    &.syntax--language {
       color: @red;
     }
   }
 
-  &.string.unquoted {
+  &.syntax--string.syntax--unquoted {
     color: @foreground;
   }
 
-  &.support {
-    &.constant {
+  &.syntax--support {
+    &.syntax--constant {
       color: @foreground;
     }
 
-    &.object {
+    &.syntax--object {
       color: @yellow;
     }
 
-    &.variable {
+    &.syntax--variable {
       color: @yellow;
     }
   }
 
-  &.meta.brace.square {
+  &.syntax--meta.syntax--brace.syntax--square {
     color: @blue;
     background-color: fadeout(@blue, 93%);
   }
 
-  &.meta.brace.curly {
+  &.syntax--meta.syntax--brace.syntax--curly {
     color: @red;
     background-color: fadeout(@red, 93%);
   }
 
-  &.meta.brace.round {
+  &.syntax--meta.syntax--brace.syntax--round {
     color: @aqua;
     background-color: fadeout(@aqua, 93%);
   }
 
-  &.meta.delimiter.period,
-  &.meta.delimiter.comma {
+  &.syntax--meta.syntax--delimiter.syntax--period,
+  &.syntax--meta.syntax--delimiter.syntax--comma {
     color: @aqua;
   }
 
-  &.meta.group.braces.round.function.arguments {
+  &.syntax--meta.syntax--group.syntax--braces.syntax--round.syntax--function.syntax--arguments {
     color: @aqua;
   }
 
-  &.punctuation {
-    &.separator.key-value {
+  &.syntax--punctuation {
+    &.syntax--separator.syntax--key-value {
       color: @aqua;
     }
 
-    &.definition {
-      &.string {
+    &.syntax--definition {
+      &.syntax--string {
         color: @green;
         background-color: fadeout(@green, 93%);
       }
 
-      &.parameters {
+      &.syntax--parameters {
         color: @aqua;
         background-color: fadeout(@aqua, 93%);
       }
 
-      &.arguments {
+      &.syntax--arguments {
         color: @aqua;
         background-color: fadeout(@aqua, 93%);
       }
 
-      &.bracket.curly {
+      &.syntax--bracket.syntax--curly {
         color: @red;
         background-color: fadeout(@red, 93%);
       }
     }
 
-    &.section.class {
+    &.syntax--section.syntax--class {
       color: @red;
       background-color: fadeout(@red, 93%);
     }
 
-    &.terminator.statement {
+    &.syntax--terminator.syntax--statement {
       color: @yellow;
     }
   }

--- a/styles/jsx.less
+++ b/styles/jsx.less
@@ -1,10 +1,10 @@
-.jsx {
-  &.punctuation.definition.tag {
+.syntax--jsx {
+  &.syntax--punctuation.syntax--definition.syntax--tag {
     color: @foreground;
     background-color: fadeout(@foreground, 93%);
   }
 
-  &.support.class.component {
+  &.syntax--support.syntax--class.syntax--component {
     color: @red;
   }
 }

--- a/styles/ruby.less
+++ b/styles/ruby.less
@@ -1,82 +1,82 @@
-.ruby {
-  &.constant.other.symbol {
+.syntax--ruby {
+  &.syntax--constant.syntax--other.syntax--symbol {
     color: @orange;
   }
 
-  &.punctuation.definition.variable {
+  &.syntax--punctuation.syntax--definition.syntax--variable {
     color: @red;
   }
 
-  &.punctuation.separator.other {
+  &.syntax--punctuation.syntax--separator.syntax--other {
     color: @aqua;
   }
 
-  &.keyword.operator.assignment {
+  &.syntax--keyword.syntax--operator.syntax--assignment {
     color: @aqua;
   }
 
-  &.keyword.operator.comparison {
+  &.syntax--keyword.syntax--operator.syntax--comparison {
     color: @aqua;
   }
 
-  &.punctuation.separator.inheritance {
+  &.syntax--punctuation.syntax--separator.syntax--inheritance {
     color: @aqua;
   }
 
-  &.keyword.operator.logical {
+  &.syntax--keyword.syntax--operator.syntax--logical {
     color: @aqua;
   }
 
-  &.keyword.operator.arithmetic {
+  &.syntax--keyword.syntax--operator.syntax--arithmetic {
     color: @aqua;
   }
 
-  &.variable.other.constant {
+  &.syntax--variable.syntax--other.syntax--constant {
     color: @yellow;
   }
 
-  &.variable.other.instance {
+  &.syntax--variable.syntax--other.syntax--instance {
     color: @red;
   }
 
-  &.variable.parameter.function {
+  &.syntax--variable.syntax--parameter.syntax--function {
     color: @orange;
   }
 
-  &.variable.other.block {
+  &.syntax--variable.syntax--other.syntax--block {
     color: @foreground;
   }
 
-  &.punctuation.separator.variable {
+  &.syntax--punctuation.syntax--separator.syntax--variable {
     color: @aqua;
   }
 
-  &.punctuation.section.array {
+  &.syntax--punctuation.syntax--section.syntax--array {
     color: @blue;
     background-color: fadeout(@blue, 93%);
   }
 
-  &.punctuation.section.scope {
+  &.syntax--punctuation.syntax--section.syntax--scope {
     color: @red;
     background-color: fadeout(@red, 93%);
   }
 
-  &.punctuation.section.regexp {
+  &.syntax--punctuation.syntax--section.syntax--regexp {
     color: @aqua;
     background-color: fadeout(@aqua, 93%);
   }
 
-  &.punctuation.definition.string {
+  &.syntax--punctuation.syntax--definition.syntax--string {
     color: @green;
     background-color: fadeout(@green, 93%);
   }
 
-  &.punctuation.definition.parameters {
+  &.syntax--punctuation.syntax--definition.syntax--parameters {
     color: @aqua;
     background-color: fadeout(@aqua, 93%);
   }
 
-  &.punctuation.section.function {
+  &.syntax--punctuation.syntax--section.syntax--function {
     color: @aqua;
     background-color: fadeout(@aqua, 93%);
   }


### PR DESCRIPTION
Updated style sheets per the 1.13 DOM style changes, detailed in the [Atom docs](http://flight-manual.atom.io/shadow-dom/sections/removing-shadow-dom-styles/).